### PR TITLE
Use CSS class for overlay styling

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -12,16 +12,7 @@ class Bot {
     if (!this.overlay) {
       this.overlay = document.createElement("div");
       this.overlay.id = "autoFollowOverlay";
-      this.overlay.style.position = "fixed";
-      this.overlay.style.bottom = "20px";
-      this.overlay.style.right = "20px";
-      this.overlay.style.backgroundColor = "rgba(0,0,0,0.8)";
-      this.overlay.style.color = "white";
-      this.overlay.style.padding = "10px";
-      this.overlay.style.borderRadius = "5px";
-      this.overlay.style.zIndex = "9999";
-      this.overlay.style.fontFamily = "Arial, sans-serif";
-      this.overlay.style.fontSize = "14px";
+      this.overlay.className = "auto-follow-overlay";
       this.overlay.innerText = "Aguardando início...";
       document.body.appendChild(this.overlay);
     }

--- a/style.css
+++ b/style.css
@@ -39,3 +39,16 @@ button:hover {
     background-color: #2a76c0;
 }
 
+.auto-follow-overlay {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    padding: 10px;
+    border-radius: 5px;
+    z-index: 9999;
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+}
+


### PR DESCRIPTION
## Summary
- Add `.auto-follow-overlay` style for auto-follow overlay
- Apply overlay style using class instead of inline styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd68d39c88326b10d5f13f3343c0a