### PR TITLE
feat: add configurable delay

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -6,6 +6,8 @@ class Bot {
     this.overlay = null;
     this.countdownInterval = null;
     this.curtirFoto = true;
+    this.minDelay = 120000;
+    this.maxDelay = 180000;
   }
 
   criarOverlay() {
@@ -23,7 +25,7 @@ class Bot {
   }
 
   getRandomDelay() {
-    return 120000 + Math.random() * 60000;
+    return this.minDelay + Math.random() * (this.maxDelay - this.minDelay);
   }
 
   startCountdown(seconds) {
@@ -133,12 +135,16 @@ class Bot {
     this.startCountdown(delaySegundos);
   }
 
-  start(limiteParam, curtir) {
+  start(limiteParam, curtir, minDelayParam, maxDelayParam) {
     if (this.rodando) return;
     this.rodando = true;
     this.perfisSeguidos = 0;
     this.limite = limiteParam || 10;
     this.curtirFoto = curtir !== undefined ? curtir : true;
+    const min = minDelayParam || 120;
+    const max = maxDelayParam || 180;
+    this.minDelay = Math.min(min, max) * 1000;
+    this.maxDelay = Math.max(min, max) * 1000;
     this.criarOverlay();
     this.seguirProximoUsuario();
   }

--- a/contentscript.js
+++ b/contentscript.js
@@ -1,4 +1,4 @@
 chrome.runtime.onMessage.addListener((msg) => {
-    if (msg.action === 'start') bot.start(msg.limite, msg.curtirFoto);
+    if (msg.action === 'start') bot.start(msg.limite, msg.curtirFoto, msg.minDelay, msg.maxDelay);
     if (msg.action === 'stop') bot.stop();
 });

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,12 @@
   <label for="quantidade">Quantidade (1-200):</label>
   <input type="number" id="quantidade" min="1" max="200" value="10">
 
+  <label for="minDelay">Delay mínimo (s):</label>
+  <input type="number" id="minDelay" min="0" value="120">
+
+  <label for="maxDelay">Delay máximo (s):</label>
+  <input type="number" id="maxDelay" min="0" value="180">
+
   <label>
     <input type="checkbox" id="curtirFoto" checked>
     Curtir primeira foto

--- a/popup.js
+++ b/popup.js
@@ -1,9 +1,18 @@
+chrome.storage.sync.get(['minDelay', 'maxDelay'], (data) => {
+    document.getElementById('minDelay').value = data.minDelay || 120;
+    document.getElementById('maxDelay').value = data.maxDelay || 180;
+});
+
 document.getElementById('startBtn').addEventListener('click', () => {
     const limite = parseInt(document.getElementById('quantidade').value) || 10;
     const curtirFoto = document.getElementById('curtirFoto').checked;
+    const minDelay = parseInt(document.getElementById('minDelay').value) || 120;
+    const maxDelay = parseInt(document.getElementById('maxDelay').value) || 180;
+
+    chrome.storage.sync.set({ minDelay, maxDelay });
 
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        chrome.tabs.sendMessage(tabs[0].id, { action: 'start', limite, curtirFoto });
+        chrome.tabs.sendMessage(tabs[0].id, { action: 'start', limite, curtirFoto, minDelay, maxDelay });
     });
 });
 


### PR DESCRIPTION
## Summary
- allow configuring delay range directly from popup
- persist user delay settings and pass to bot runtime
- use configurable delay range for randomized countdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fd74feb948326ab4b9ca62ecaea6e