### PR TITLE
refactor: centralize tab messaging helper

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -3,6 +3,12 @@ chrome.storage.sync.get(['minDelay', 'maxDelay'], (data) => {
     document.getElementById('maxDelay').value = data.maxDelay || 180;
 });
 
+function sendMessageToActiveTab(message) {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        chrome.tabs.sendMessage(tabs[0].id, message);
+    });
+}
+
 document.getElementById('startBtn').addEventListener('click', () => {
     const limite = parseInt(document.getElementById('quantidade').value) || 10;
     const curtirFoto = document.getElementById('curtirFoto').checked;
@@ -11,13 +17,9 @@ document.getElementById('startBtn').addEventListener('click', () => {
 
     chrome.storage.sync.set({ minDelay, maxDelay });
 
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        chrome.tabs.sendMessage(tabs[0].id, { action: 'start', limite, curtirFoto, minDelay, maxDelay });
-    });
+    sendMessageToActiveTab({ action: 'start', limite, curtirFoto, minDelay, maxDelay });
 });
 
 document.getElementById('stopBtn').addEventListener('click', () => {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        chrome.tabs.sendMessage(tabs[0].id, { action: 'stop' });
-    });
+    sendMessageToActiveTab({ action: 'stop' });
 });


### PR DESCRIPTION
## Summary
- add `sendMessageToActiveTab` helper to reuse active tab message logic
- use helper for start and stop actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd8423db88326abdebdfb6d97b8c7