### PR TITLE
Persist limiter and like preference in popup

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,6 @@
-chrome.storage.sync.get(['minDelay', 'maxDelay'], (data) => {
+chrome.storage.sync.get(['minDelay', 'maxDelay', 'limite', 'curtirFoto'], (data) => {
+    document.getElementById('quantidade').value = data.limite || 10;
+    document.getElementById('curtirFoto').checked = data.curtirFoto !== undefined ? data.curtirFoto : true;
     document.getElementById('minDelay').value = data.minDelay || 120;
     document.getElementById('maxDelay').value = data.maxDelay || 180;
 });
@@ -15,7 +17,7 @@ document.getElementById('startBtn').addEventListener('click', () => {
     const minDelay = parseInt(document.getElementById('minDelay').value) || 120;
     const maxDelay = parseInt(document.getElementById('maxDelay').value) || 180;
 
-    chrome.storage.sync.set({ minDelay, maxDelay });
+    chrome.storage.sync.set({ minDelay, maxDelay, limite, curtirFoto });
 
     sendMessageToActiveTab({ action: 'start', limite, curtirFoto, minDelay, maxDelay });
 });


### PR DESCRIPTION
## Summary
- Restore `limite` and `curtirFoto` settings when popup opens
- Persist limiter and like option to `chrome.storage` on start

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd8e80ff0832699e2bf97a3bdafd1