### PR TITLE
feat: restore overlay and add first-photo liker

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,33 @@
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'LIKE_REQUEST') {
+    const username = msg.username;
+    chrome.tabs.create({ url: `https://www.instagram.com/${username}/`, active: false }, (tab) => {
+      const tabId = tab.id;
+
+      const handleUpdated = (updatedTabId, info) => {
+        if (updatedTabId === tabId && info.status === 'complete') {
+          chrome.tabs.onUpdated.removeListener(handleUpdated);
+          chrome.scripting.executeScript({
+            target: { tabId },
+            files: ['liker.js']
+          });
+        }
+      };
+      chrome.tabs.onUpdated.addListener(handleUpdated);
+
+      const handleMessage = (response, senderInfo) => {
+        if (
+          senderInfo.tab &&
+          senderInfo.tab.id === tabId &&
+          (response.type === 'LIKE_DONE' || response.type === 'LIKE_SKIP')
+        ) {
+          chrome.runtime.onMessage.removeListener(handleMessage);
+          chrome.tabs.remove(tabId);
+          sendResponse({ result: response.type });
+        }
+      };
+      chrome.runtime.onMessage.addListener(handleMessage);
+    });
+    return true; // Keep the message channel open for sendResponse
+  }
+});

--- a/liker.js
+++ b/liker.js
@@ -1,0 +1,23 @@
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  const firstPost = document.querySelector('a[href*="/p/"]');
+  if (!firstPost) {
+    chrome.runtime.sendMessage({ type: 'LIKE_SKIP' });
+    return;
+  }
+
+  firstPost.click();
+  await sleep(1500);
+
+  const btnCurtir = document.querySelector('svg[aria-label="Curtir"], svg[aria-label="Like"]');
+  if (btnCurtir && btnCurtir.closest('button')) {
+    btnCurtir.closest('button').click();
+    await sleep(1000);
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    chrome.runtime.sendMessage({ type: 'LIKE_DONE' });
+  } else {
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    chrome.runtime.sendMessage({ type: 'LIKE_SKIP' });
+  }
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -3,16 +3,29 @@
   "name": "Instagram Auto Follow RSX",
   "version": "1.1",
   "description": "Segue automaticamente perfis no modal de seguidores com limite e delay aleatório.",
-  "permissions": ["activeTab", "scripting", "storage"],
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "storage",
+    "tabs"
+  ],
+  "host_permissions": [
+    "https://www.instagram.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
     "default_popup": "popup.html"
   },
   "content_scripts": [
-      {
-        "matches": ["https://www.instagram.com/*"],
-        "js": ["bot.js", "contentscript.js"]
-      }
-    ]
-  }
+    {
+      "matches": [
+        "https://www.instagram.com/*"
+      ],
+      "js": ["bot.js", "contentscript.js"]
+    }
+  ]
+}
 
 

--- a/style.css
+++ b/style.css
@@ -39,7 +39,7 @@ button:hover {
     background-color: #2a76c0;
 }
 
-.auto-follow-overlay {
+#autoFollowOverlay {
     position: fixed;
     bottom: 20px;
     right: 20px;
@@ -50,5 +50,22 @@ button:hover {
     z-index: 9999;
     font-family: Arial, sans-serif;
     font-size: 14px;
+    white-space: pre-line;
+}
+
+#autoFollowLog {
+    position: fixed;
+    top: 20px;
+    left: 20px;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    padding: 10px;
+    border-radius: 5px;
+    z-index: 9999;
+    font-family: Arial, sans-serif;
+    font-size: 14px;
+    max-height: 60vh;
+    overflow-y: auto;
+    white-space: pre-line;
 }
 


### PR DESCRIPTION
## Summary
- restore status overlay and introduce log overlay for followed accounts
- coordinate first-photo likes via background service worker and liker content script
- update manifest and styles for new overlays and permissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fdd5ef2e0832694741daa6b18bdce