### PR TITLE
Improve like flow and username extraction

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -123,20 +123,21 @@ class Bot {
   }
 
   extrairUsername(btn) {
-    const container = btn.closest('li') || btn.parentElement;
+    const container = btn.closest('li, div');
     if (container) {
-      const link = container.querySelector('a[href^="/"]');
+      const link = container.querySelector('a[href^="/"][href$="/"]');
       if (link) {
-        const match = link.getAttribute('href').match(/^\/([^\/]+)/);
+        const href = link.getAttribute('href');
+        const match = href.match(/^\/([^\/]+)/);
         if (match) return match[1];
         if (link.innerText) return link.innerText.trim();
       }
       const span = container.querySelector('span[dir="auto"]');
-      if (span && span.innerText) return span.innerText.trim();
+      if (span && span.innerText) return span.innerText.trim().replace(/^@/, '');
       const txt = container.innerText.replace(/\n/g, ' ').trim();
       if (txt) return txt.split(' ')[0].replace('@', '');
     }
-    return 'usuario';
+    return 'desconhecido';
   }
 
   requestLike(username) {

--- a/liker.js
+++ b/liker.js
@@ -1,42 +1,74 @@
+// Script responsável por curtir a primeira publicação de um perfil
+// É injetado pelo background em uma aba de perfil
 (async () => {
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-  const isPrivate = () => /esta conta é privada|this account is private/i.test(document.body.innerText);
-
-  let opened = false;
-  for (let i = 0; i < 15; i++) {
-    if (isPrivate()) {
-      chrome.runtime.sendMessage({ type: 'LIKE_SKIP' });
-      return;
+  const waitFor = async (fn, timeout = 20000, interval = 500) => {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      const res = fn();
+      if (res) return res;
+      await sleep(interval);
     }
-    const firstThumb = document.querySelector('article a');
-    if (firstThumb) {
-      firstThumb.click();
-      opened = true;
-      break;
+    return null;
+  };
+  const send = (type, reason) => chrome.runtime.sendMessage(reason ? { type, reason } : { type });
+
+  const privateRegex = /esta conta é privada|this account is private/i;
+
+  try {
+    const main = await waitFor(() => document.querySelector('main'));
+    if (!main) return send('LIKE_SKIP', 'timeout');
+
+    if (privateRegex.test(document.body.innerText)) {
+      return send('LIKE_SKIP', 'private');
     }
-    await sleep(1000);
-  }
 
-  if (!opened) {
-    chrome.runtime.sendMessage({ type: 'LIKE_SKIP' });
-    return;
-  }
+    const thumb = await waitFor(() =>
+      main.querySelector('a[href*="/p/"], a[href*="/reel/"]')
+    );
+    if (!thumb) return send('LIKE_SKIP', 'no_post');
 
-  await sleep(1500);
+    thumb.click();
 
-  let result = 'LIKE_DONE';
-  const btnCurtir = document.querySelector('svg[aria-label="Curtir"], svg[aria-label="Like"]');
-  if (btnCurtir && btnCurtir.closest('button')) {
-    const btn = btnCurtir.closest('button');
-    if (btn.getAttribute('aria-pressed') !== 'true') {
-      btn.click();
+    const dialog = await waitFor(() => document.querySelector('div[role="dialog"]'));
+    if (!dialog) return send('LIKE_SKIP', 'timeout');
+
+    const likeBtn = await waitFor(() => {
+      const svg = dialog.querySelector('svg[aria-label="Curtir"], svg[aria-label="Like"]');
+      return svg && svg.closest('button');
+    }, 5000);
+
+    let liked = false;
+    if (likeBtn) {
+      if (likeBtn.getAttribute('aria-pressed') === 'true') {
+        liked = true;
+      } else {
+        likeBtn.click();
+        await sleep(1000);
+        liked = likeBtn.getAttribute('aria-pressed') === 'true';
+      }
+    }
+
+    if (!liked) {
+      dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'l', bubbles: true }));
       await sleep(500);
+      if (likeBtn) {
+        liked = likeBtn.getAttribute('aria-pressed') === 'true';
+      } else {
+        const svg = dialog.querySelector('svg[aria-label="Curtir"], svg[aria-label="Like"]');
+        const btn = svg && svg.closest('button');
+        liked = btn && btn.getAttribute('aria-pressed') === 'true';
+      }
     }
-  } else {
-    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'l' }));
-    await sleep(500);
-  }
 
-  document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-  chrome.runtime.sendMessage({ type: result });
+    if (liked) {
+      send('LIKE_DONE');
+    } else {
+      send('LIKE_SKIP', likeBtn ? 'selector_miss' : 'selector_miss');
+    }
+  } catch (e) {
+    send('LIKE_SKIP', 'timeout');
+  } finally {
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+  }
 })();


### PR DESCRIPTION
## Summary
- improve liker script to be patient and handle private accounts and liking via fallback
- extract usernames from follower list more robustly so log overlay shows @username

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fea5c583083269e481f2f9e5ef54f