### PR TITLE
Improve username lookup and like reliability

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,8 @@
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.type === 'LIKE_REQUEST') {
     const username = msg.username;
-    chrome.tabs.create({ url: `https://www.instagram.com/${username}/`, active: false }, (tab) => {
+    const originTabId = sender.tab ? sender.tab.id : null;
+    chrome.tabs.create({ url: `https://www.instagram.com/${username}/`, active: true }, (tab) => {
       const tabId = tab.id;
       let responded = false;
       let timeoutId;
@@ -12,7 +13,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         clearTimeout(timeoutId);
         chrome.runtime.onMessage.removeListener(handleMessage);
         chrome.tabs.onUpdated.removeListener(handleUpdated);
-        chrome.tabs.remove(tabId);
+        chrome.tabs.remove(tabId, () => {
+          if (originTabId) chrome.tabs.update(originTabId, { active: true });
+        });
         sendResponse({ result });
       };
 
@@ -38,7 +41,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       };
       chrome.runtime.onMessage.addListener(handleMessage);
 
-      timeoutId = setTimeout(() => cleanUp('LIKE_SKIP'), 15000);
+      timeoutId = setTimeout(() => cleanUp('LIKE_SKIP'), 25000);
     });
     return true; // Keep the message channel open for sendResponse
   }

--- a/bot.js
+++ b/bot.js
@@ -123,20 +123,56 @@ class Bot {
   }
 
   extrairUsername(btn) {
-    const container = btn.closest('li, div');
-    if (container) {
-      const link = container.querySelector('a[href^="/"][href$="/"]');
-      if (link) {
+    const avoid = [
+      'p',
+      'reel',
+      'reels',
+      'explore',
+      'accounts',
+      'stories',
+      'direct',
+      'challenge',
+      'tv'
+    ];
+
+    const btnText = btn.innerText.trim().toLowerCase();
+    const isValid = (text) => {
+      if (!text) return false;
+      const t = text.trim().replace(/^@/, '');
+      if (!t) return false;
+      if (t.toLowerCase() === btnText) return false;
+      return /^[a-z0-9._]+$/i.test(t);
+    };
+
+    let current = btn;
+    for (let i = 0; i < 8 && current; i++) {
+      current = current.parentElement;
+      if (!current) break;
+
+      const links = Array.from(
+        current.querySelectorAll('a[href^="/"][href$="/"]')
+      ).filter((a) => !btn.contains(a));
+
+      for (const link of links) {
         const href = link.getAttribute('href');
-        const match = href.match(/^\/([^\/]+)/);
-        if (match) return match[1];
-        if (link.innerText) return link.innerText.trim();
+        const match = href.match(/^\/([^\/]+)\/$/);
+        if (match && !avoid.includes(match[1].toLowerCase())) {
+          return match[1];
+        }
       }
-      const span = container.querySelector('span[dir="auto"]');
-      if (span && span.innerText) return span.innerText.trim().replace(/^@/, '');
-      const txt = container.innerText.replace(/\n/g, ' ').trim();
-      if (txt) return txt.split(' ')[0].replace('@', '');
+
+      const textNodes = Array.from(
+        current.querySelectorAll('span, div')
+      ).filter((el) => !btn.contains(el));
+
+      for (const el of textNodes) {
+        const text = el.textContent.trim();
+        if (isValid(text)) {
+          return text.replace(/^@/, '');
+        }
+      }
     }
+
     return 'desconhecido';
   }
 

--- a/liker.js
+++ b/liker.js
@@ -28,7 +28,17 @@
     );
     if (!thumb) return send('LIKE_SKIP', 'no_post');
 
-    thumb.click();
+    const simulateClick = (el) => {
+      try {
+        el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+        el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+        el.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      } catch (e) {
+        el.click();
+      }
+    };
+    simulateClick(thumb);
 
     const dialog = await waitFor(() => document.querySelector('div[role="dialog"]'));
     if (!dialog) return send('LIKE_SKIP', 'timeout');


### PR DESCRIPTION
## Summary
- climb up from follow button to find profile link and ignore non-profile routes
- open like tab in foreground and return to original tab
- simulate full click sequence on first thumbnail before liking
- add fallback to nearby spans/divs and ignore follow button text to prevent '@Seguir'

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fece501c08326a80e5ee9e041b974