### PR TITLE
Improve like automation flow

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,48 +1,83 @@
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.type === 'LIKE_REQUEST') {
     const username = msg.username;
-    const originTabId = sender.tab ? sender.tab.id : null;
-    chrome.tabs.create({ url: `https://www.instagram.com/${username}/`, active: true }, (tab) => {
-      const tabId = tab.id;
-      let responded = false;
-      let timeoutId;
 
-      const cleanUp = (result) => {
-        if (responded) return;
-        responded = true;
-        clearTimeout(timeoutId);
-        chrome.runtime.onMessage.removeListener(handleMessage);
-        chrome.tabs.onUpdated.removeListener(handleUpdated);
-        chrome.tabs.remove(tabId, () => {
-          if (originTabId) chrome.tabs.update(originTabId, { active: true });
-        });
-        sendResponse({ result });
-      };
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const originTabId = tabs[0] ? tabs[0].id : null;
 
-      const handleUpdated = (updatedTabId, info) => {
-        if (updatedTabId === tabId && info.status === 'complete') {
-          chrome.tabs.onUpdated.removeListener(handleUpdated);
-          chrome.scripting.executeScript({
-            target: { tabId },
-            files: ['liker.js']
-          });
+      chrome.tabs.create(
+        {
+          url: `https://www.instagram.com/${username}/`,
+          active: false,
+        },
+        (tab) => {
+          const tabId = tab.id;
+          let done = false;
+          let activated = false;
+          let timeoutId;
+
+          const finalize = (result) => {
+            if (done) return;
+            done = true;
+            clearTimeout(timeoutId);
+            chrome.runtime.onMessage.removeListener(handleMessage);
+            chrome.tabs.onUpdated.removeListener(handleUpdated);
+            chrome.tabs.remove(tabId, () => {
+              if (originTabId) chrome.tabs.update(originTabId, { active: true });
+            });
+            sendResponse({ result });
+          };
+
+          const inject = (attempt = 1) => {
+            chrome.scripting.executeScript(
+              { target: { tabId }, files: ['liker.js'] },
+              () => {
+                const err = chrome.runtime.lastError;
+                if (
+                  err &&
+                  /Frame.*was removed|No frame/i.test(err.message || '') &&
+                  attempt < 3
+                ) {
+                  setTimeout(() => inject(attempt + 1), 350);
+                }
+              }
+            );
+          };
+
+          const handleUpdated = (updatedTabId, info) => {
+            if (updatedTabId === tabId && info.status === 'complete') {
+              chrome.tabs.onUpdated.removeListener(handleUpdated);
+              inject();
+            }
+          };
+          chrome.tabs.onUpdated.addListener(handleUpdated);
+
+          const handleMessage = (response, senderInfo) => {
+            if (senderInfo.tab && senderInfo.tab.id === tabId) {
+              if (response.type === 'LIKE_DONE') {
+                finalize('LIKE_DONE');
+              } else if (response.type === 'LIKE_SKIP') {
+                if (
+                  !activated &&
+                  (response.reason === 'not_visible' || response.reason === 'no_post')
+                ) {
+                  activated = true;
+                  chrome.tabs.update(tabId, { active: true }, () => {
+                    setTimeout(() => inject(), 400);
+                  });
+                } else {
+                  finalize('LIKE_SKIP');
+                }
+              }
+            }
+          };
+          chrome.runtime.onMessage.addListener(handleMessage);
+
+          timeoutId = setTimeout(() => finalize('LIKE_SKIP'), 20000);
         }
-      };
-      chrome.tabs.onUpdated.addListener(handleUpdated);
-
-      const handleMessage = (response, senderInfo) => {
-        if (
-          senderInfo.tab &&
-          senderInfo.tab.id === tabId &&
-          (response.type === 'LIKE_DONE' || response.type === 'LIKE_SKIP')
-        ) {
-          cleanUp(response.type);
-        }
-      };
-      chrome.runtime.onMessage.addListener(handleMessage);
-
-      timeoutId = setTimeout(() => cleanUp('LIKE_SKIP'), 25000);
+      );
     });
+
     return true; // Keep the message channel open for sendResponse
   }
 });

--- a/liker.js
+++ b/liker.js
@@ -1,84 +1,118 @@
 // Script responsável por curtir a primeira publicação de um perfil
-// É injetado pelo background em uma aba de perfil
+// É injetado pelo background em uma aba de perfil ou diretamente no post
 (async () => {
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-  const waitFor = async (fn, timeout = 20000, interval = 500) => {
+  const waitFor = async (fn, timeout = 20000, interval = 100) => {
     const start = Date.now();
     while (Date.now() - start < timeout) {
-      const res = fn();
-      if (res) return res;
+      const result = fn();
+      if (result) return result;
       await sleep(interval);
     }
     return null;
   };
-  const send = (type, reason) => chrome.runtime.sendMessage(reason ? { type, reason } : { type });
-
-  const privateRegex = /esta conta é privada|this account is private/i;
+  const send = (type, reason) =>
+    chrome.runtime.sendMessage(reason ? { type, reason } : { type });
 
   try {
-    const main = await waitFor(() => document.querySelector('main'));
-    if (!main) return send('LIKE_SKIP', 'timeout');
+    await waitFor(() => document.readyState === 'complete');
 
-    if (privateRegex.test(document.body.innerText)) {
+    if (document.visibilityState !== 'visible') {
+      return send('LIKE_SKIP', 'not_visible');
+    }
+
+    const text = document.body.innerText || '';
+    if (/esta conta é privada|this account is private/i.test(text)) {
       return send('LIKE_SKIP', 'private');
     }
 
-    const thumb = await waitFor(() =>
-      main.querySelector('a[href*="/p/"], a[href*="/reel/"]')
-    );
-    if (!thumb) return send('LIKE_SKIP', 'no_post');
+    const main = document.querySelector('main');
+    if (!main) return send('LIKE_SKIP', 'no_post');
 
-    const simulateClick = (el) => {
-      try {
-        el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-        el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
-        el.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
-        el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      } catch (e) {
-        el.click();
+    let anchor =
+      main.querySelector('article a[href*="/p/"]') ||
+      main.querySelector('article a[href*="/reel/"]') ||
+      main.querySelector('a[href*="/p/"], a[href*="/reel/"]');
+    if (!anchor) {
+      const img = main.querySelector('article img');
+      if (img) {
+        anchor = img.closest('a,[role="button"]');
       }
+    }
+    if (!anchor) return send('LIKE_SKIP', 'no_post');
+
+    const url = new URL(anchor.getAttribute('href'), location.origin);
+    location.assign(url);
+    await waitFor(() => /(\/p\/|\/reel\/)/.test(location.pathname), 10000);
+    await waitFor(() => document.readyState === 'complete');
+
+    const article = await waitFor(() => document.querySelector('article'));
+    if (!article) return send('LIKE_SKIP', 'no_post');
+
+    const getBtn = () => {
+      const svg = article.querySelector(
+        'svg[aria-label="Curtir"], svg[aria-label="Like"], svg[aria-label="Descurtir"], svg[aria-label="Unlike"]'
+      );
+      return { svg, btn: svg ? svg.closest('button,[role="button"]') : null };
     };
-    simulateClick(thumb);
 
-    const dialog = await waitFor(() => document.querySelector('div[role="dialog"]'));
-    if (!dialog) return send('LIKE_SKIP', 'timeout');
+    const isLiked = ({ svg, btn }) => {
+      const label = svg ? svg.getAttribute('aria-label') || '' : '';
+      return (
+        (btn && btn.getAttribute('aria-pressed') === 'true') ||
+        /Descurtir|Unlike/i.test(label)
+      );
+    };
 
-    const likeBtn = await waitFor(() => {
-      const svg = dialog.querySelector('svg[aria-label="Curtir"], svg[aria-label="Like"]');
-      return svg && svg.closest('button');
-    }, 5000);
+    let { svg, btn } = getBtn();
+    let liked = isLiked({ svg, btn });
 
-    let liked = false;
-    if (likeBtn) {
-      if (likeBtn.getAttribute('aria-pressed') === 'true') {
-        liked = true;
-      } else {
-        likeBtn.click();
-        await sleep(1000);
-        liked = likeBtn.getAttribute('aria-pressed') === 'true';
-      }
+    const tryClick = async (target) => {
+      if (!target) return;
+      target.click();
+      await sleep(500);
+      ({ svg, btn } = getBtn());
+      liked = isLiked({ svg, btn });
+    };
+
+    if (!liked && btn) {
+      await tryClick(btn);
+      if (!liked && svg) await tryClick(svg);
     }
 
     if (!liked) {
-      dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'l', bubbles: true }));
+      article.click();
+      article.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'l', bubbles: true })
+      );
       await sleep(500);
-      if (likeBtn) {
-        liked = likeBtn.getAttribute('aria-pressed') === 'true';
-      } else {
-        const svg = dialog.querySelector('svg[aria-label="Curtir"], svg[aria-label="Like"]');
-        const btn = svg && svg.closest('button');
-        liked = btn && btn.getAttribute('aria-pressed') === 'true';
+      ({ svg, btn } = getBtn());
+      liked = isLiked({ svg, btn });
+    }
+
+    if (!liked) {
+      const media = article.querySelector('img, video');
+      if (media) {
+        const rect = media.getBoundingClientRect();
+        const opts = {
+          bubbles: true,
+          clientX: rect.left + rect.width / 2,
+          clientY: rect.top + rect.height / 2,
+        };
+        media.dispatchEvent(new MouseEvent('click', opts));
+        media.dispatchEvent(new MouseEvent('click', opts));
+        await sleep(500);
+        ({ svg, btn } = getBtn());
+        liked = isLiked({ svg, btn });
       }
     }
 
     if (liked) {
       send('LIKE_DONE');
     } else {
-      send('LIKE_SKIP', likeBtn ? 'selector_miss' : 'selector_miss');
+      send('LIKE_SKIP', 'state_not_changed');
     }
   } catch (e) {
-    send('LIKE_SKIP', 'timeout');
-  } finally {
-    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    send('LIKE_SKIP', 'error');
   }
 })();


### PR DESCRIPTION
## Summary
- Rebuild liker script to wait for visibility, navigate directly to first post and attempt multiple like strategies with fallbacks
- Enhance background logic to inject liker script with retries, activate hidden tab on demand and ensure cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fffebaad08326939911b08fbabdd2