### PR TITLE
Restore first-post like flow with follow checks

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,8 @@
 // background.js
-// Service worker handling tab operations and profile follow checks
+// Service worker handling tab operations and profile follow checks/likes
 
 const CHECK_TIMEOUT = 15000; // 15s overall timeout
+const LIKE_TIMEOUT = 20000; // 20s overall timeout
 
 async function checkFollowsMe(username) {
   const result = await new Promise(async (resolve) => {
@@ -71,4 +72,68 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     checkFollowsMe(msg.username).then(sendResponse);
     return true; // keep the message channel open
   }
+  if (msg.type === 'LIKE_REQUEST') {
+    likeFirstPost(msg.username).then(sendResponse);
+    return true;
+  }
 });
+
+async function likeFirstPost(username) {
+  const result = await new Promise(async (resolve) => {
+    let originalTab = (await chrome.tabs.query({ active: true, currentWindow: true }))[0];
+    let tempTab = await chrome.tabs.create({ url: `https://www.instagram.com/${username}/`, active: false });
+    let tempTabId = tempTab.id;
+    let done = false;
+    let activated = false;
+
+    const timer = setTimeout(() => finalize('LIKE_SKIP', 'timeout'), LIKE_TIMEOUT);
+
+    function finalize(status, reason) {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      chrome.runtime.onMessage.removeListener(messageListener);
+      chrome.tabs.onUpdated.removeListener(updateListener);
+      if (tempTabId) chrome.tabs.remove(tempTabId);
+      if (originalTab && originalTab.id) chrome.tabs.update(originalTab.id, { active: true });
+      if (status === 'LIKE_DONE') resolve({ result: 'LIKE_DONE' });
+      else resolve({ result: 'LIKE_SKIP', reason });
+    }
+
+    function inject(attempt = 0) {
+      chrome.scripting
+        .executeScript({ target: { tabId: tempTabId }, files: ['liker.js'], world: 'MAIN' })
+        .catch((err) => {
+          console.log('[LIKE] inject error', err.message);
+          if (/No frame|Frame.*removed/i.test(err.message) && attempt < 3) {
+            setTimeout(() => inject(attempt + 1), 300);
+          } else {
+            finalize('LIKE_SKIP', 'error');
+          }
+        });
+    }
+
+    function messageListener(msg, sender) {
+      if (!sender.tab || sender.tab.id !== tempTabId || msg.type !== 'LIKE_RESULT') return;
+      console.log('[LIKE] result', msg.status, msg.reason);
+      if ((msg.reason === 'not_visible' || msg.reason === 'no_post') && !activated) {
+        activated = true;
+        chrome.tabs.update(tempTabId, { active: true }, () => setTimeout(() => inject(), 300));
+        return;
+      }
+      finalize(msg.status, msg.reason);
+    }
+
+    function updateListener(tabId, info) {
+      if (tabId === tempTabId && info.status === 'complete') {
+        chrome.tabs.onUpdated.removeListener(updateListener);
+        inject();
+      }
+    }
+
+    chrome.runtime.onMessage.addListener(messageListener);
+    chrome.tabs.onUpdated.addListener(updateListener);
+  });
+
+  return result;
+}

--- a/liker.js
+++ b/liker.js
@@ -1,0 +1,141 @@
+// liker.js
+// Injected into Instagram profile to like first post/reel
+(function () {
+  const CLOSE_TOKENS = [
+    'agora não',
+    'agora nao',
+    'not now',
+    'salvar informações',
+    'save info',
+    'ativar notificações',
+    'turn on notifications'
+  ];
+  const PRIVATE_TOKENS = ['esta conta é privada', 'this account is private'];
+
+  function log(...args) {
+    console.log('[LIKER]', ...args);
+  }
+
+  function normalize(t) {
+    return t ? t.toLowerCase().replace(/\s+/g, ' ').trim() : '';
+  }
+
+  function closeOverlays() {
+    const buttons = Array.from(document.querySelectorAll('button'));
+    buttons.forEach((btn) => {
+      const txt = normalize(btn.innerText);
+      if (CLOSE_TOKENS.some((ct) => txt.includes(ct))) btn.click();
+    });
+  }
+
+  function send(status, reason) {
+    chrome.runtime.sendMessage({ type: 'LIKE_RESULT', status, reason });
+  }
+
+  function waitFor(cond, timeout = 5000) {
+    return new Promise((resolve) => {
+      const start = Date.now();
+      (function check() {
+        if (cond()) return resolve(true);
+        if (Date.now() - start > timeout) return resolve(false);
+        setTimeout(check, 200);
+      })();
+    });
+  }
+
+  async function like() {
+    if (document.visibilityState !== 'visible') {
+      send('LIKE_SKIP', 'not_visible');
+      return;
+    }
+
+    closeOverlays();
+
+    const bodyText = normalize(document.body.innerText || '');
+    if (PRIVATE_TOKENS.some((t) => bodyText.includes(t))) {
+      send('LIKE_SKIP', 'private');
+      return;
+    }
+
+    let first = document.querySelector('main article a[href*="/p/"], main article a[href*="/reel/"]');
+    if (!first) {
+      const img = document.querySelector('main article img');
+      first = img ? img.closest('a[href]') : null;
+    }
+    if (!first) {
+      send('LIKE_SKIP', 'no_post');
+      return;
+    }
+
+    first.click();
+    const overlayLoaded = await waitFor(() =>
+      document.querySelector('article div[role="button"]') ||
+      document.querySelector('svg[aria-label*="Curtir"], svg[aria-label*="Like"]')
+    , 5000);
+    if (!overlayLoaded) {
+      send('LIKE_SKIP', 'not_visible');
+      return;
+    }
+
+    closeOverlays();
+    await new Promise((r) => setTimeout(r, 200));
+
+    let likeBtn = Array.from(document.querySelectorAll('button[aria-label], svg[aria-label]'))
+      .map((el) => el.closest('button'))
+      .find((btn) => {
+        const lbl = normalize(btn.getAttribute('aria-label'));
+        return /curtir|like/.test(lbl);
+      });
+
+    const media = document.querySelector('article img, article video');
+
+    async function attemptFallbacks() {
+      if (likeBtn) {
+        likeBtn.click();
+        return;
+      }
+      if (media) {
+        media.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+        await new Promise((r) => setTimeout(r, 300));
+      }
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'l', bubbles: true }));
+      document.dispatchEvent(new KeyboardEvent('keyup', { key: 'l', bubbles: true }));
+    }
+
+    await attemptFallbacks();
+    await new Promise((r) => setTimeout(r, 500));
+
+    likeBtn = Array.from(document.querySelectorAll('button[aria-label], svg[aria-label]'))
+      .map((el) => el.closest('button'))
+      .find((btn) => {
+        const pressed = btn.getAttribute('aria-pressed');
+        const lbl = normalize(btn.getAttribute('aria-label'));
+        const svg = btn.querySelector('svg path');
+        return (
+          pressed === 'true' ||
+          /descurtir|unlike/.test(lbl) ||
+          (svg && svg.getAttribute('fill') && svg.getAttribute('fill') !== 'none')
+        );
+      });
+
+    if (likeBtn) {
+      send('LIKE_DONE');
+    } else {
+      send('LIKE_SKIP', 'state_not_changed');
+    }
+  }
+
+  if (document.readyState === 'complete') {
+    like().catch((e) => {
+      log('error', e);
+      send('LIKE_SKIP', 'error');
+    });
+  } else {
+    window.addEventListener('load', () =>
+      like().catch((e) => {
+        log('error', e);
+        send('LIKE_SKIP', 'error');
+      })
+    );
+  }
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -3,14 +3,14 @@
   "name": "Instagram Auto Follow RSX",
   "version": "1.1",
   "description": "Segue automaticamente perfis no modal de seguidores com limite e delay aleatório.",
-  "permissions": ["activeTab", "scripting", "storage", "tabs"],
+  "permissions": ["scripting", "tabs"],
   "host_permissions": ["https://www.instagram.com/*"],
   "background": {
     "service_worker": "background.js"
   },
   "web_accessible_resources": [
     {
-      "resources": ["checker.js"],
+      "resources": ["checker.js", "liker.js"],
       "matches": ["https://www.instagram.com/*"]
     }
   ],

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,11 @@
   <label for="quantidade">Quantidade (1-50):</label>
   <input type="number" id="quantidade" min="1" max="50" value="10">
 
+  <div>
+    <input type="checkbox" id="likeFirst" checked>
+    <label for="likeFirst">Curtir primeira foto</label>
+  </div>
+
   <button id="startBtn">Iniciar</button>
   <button id="stopBtn">Parar</button>
 

--- a/popup.js
+++ b/popup.js
@@ -2,8 +2,9 @@
 
 document.getElementById('startBtn').addEventListener('click', () => {
     const limite = parseInt(document.getElementById('quantidade').value) || 10;
+    const likeFirst = document.getElementById('likeFirst').checked;
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        chrome.tabs.sendMessage(tabs[0].id, { action: 'start', limite });
+        chrome.tabs.sendMessage(tabs[0].id, { action: 'start', limite, likeFirst });
     });
 });
 


### PR DESCRIPTION
## Summary
- add liker.js to open first post, handle like attempts, and report results
- support LIKE_REQUEST in background for temporary tab flow
- check "follows you" before following and optionally like first post via new popup option

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a220c0979c8326abc28968937666c4