### PR TITLE
Skip follow-back profiles and improve follower detection

### DIFF
--- a/background.js
+++ b/background.js
@@ -39,6 +39,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     const onMsg = (res, snd) => {
       if (!snd?.tab || snd.tab.id !== tabId) return;
       if (res?.type === 'CHECK_RESULT') {
+        // FOLLOWS_YOU cobre tanto "Segue você" quanto o botão "Seguir de volta"
         if (res.result === 'FOLLOWS_YOU' || res.result === 'NOT_FOLLOWING') {
           finalize(res.result);
         } else if (!secondTry && res.reason === 'not_visible') {

--- a/bot.js
+++ b/bot.js
@@ -178,35 +178,48 @@ class Bot {
       return;
     }
 
-    const btn = Array.from(modalInterno.querySelectorAll('button')).find((b) => {
-      const t = (b.innerText || '').trim().toLowerCase();
-      return t === 'seguir' || t === 'follow';
-    });
+    let acted = false;
+    const buttons = Array.from(modalInterno.querySelectorAll('button'));
+    for (const btn of buttons) {
+      const t = (btn.innerText || '').trim().toLowerCase();
 
-
-    if (btn) {
-      const username = await this.extractUsernameFromFollowButton(btn);
-      const check = await this.requestCheckFollows(username);
-      if (check === 'FOLLOWS_YOU') {
-        this.addLog(username, '⏭️ já segue você');
-        this.atualizarOverlay(`@${username} ⏭️ já segue você (${this.perfisSeguidos}/${this.limite})`);
-      } else {
-        btn.click();
-        this.perfisSeguidos++;
-        this.addLog(username);
-
-        if (this.curtirFoto) {
-          this.atualizarOverlay(`Curtindo primeira foto de @${username}... (${this.perfisSeguidos}/${this.limite})`);
-          const result = await this.requestLike(username);
-          if (result === 'LIKE_DONE') { this.likesOk++; this.addLog(username, '♥️'); }
-          else { this.likesSkip++; this.addLog(username, '⏭️'); }
-        } else {
-          this.atualizarOverlay(`Seguido @${username} (${this.perfisSeguidos}/${this.limite})`);
-        }
+      if (t === 'seguir de volta' || t === 'follow back') {
+        const username = await this.extractUsernameFromFollowButton(btn);
+        this.addLog(username, '⏭️ já segue (seguir de volta)');
+        this.atualizarOverlay(`@${username} ⏭️ já segue (seguir de volta) (${this.perfisSeguidos}/${this.limite})`);
+        modalInterno.scrollTop += 70;
+        acted = true;
+        break;
       }
 
-      modalInterno.scrollTop += 70;
-    } else {
+      if (t === 'seguir' || t === 'follow') {
+        const username = await this.extractUsernameFromFollowButton(btn);
+        const check = await this.requestCheckFollows(username);
+        if (check === 'FOLLOWS_YOU') {
+          this.addLog(username, '⏭️ já segue você');
+          this.atualizarOverlay(`@${username} ⏭️ já segue você (${this.perfisSeguidos}/${this.limite})`);
+        } else {
+          btn.click();
+          this.perfisSeguidos++;
+          this.addLog(username);
+
+          if (this.curtirFoto) {
+            this.atualizarOverlay(`Curtindo primeira foto de @${username}... (${this.perfisSeguidos}/${this.limite})`);
+            const result = await this.requestLike(username);
+            if (result === 'LIKE_DONE') { this.likesOk++; this.addLog(username, '♥️'); }
+            else { this.likesSkip++; this.addLog(username, '⏭️'); }
+          } else {
+            this.atualizarOverlay(`Seguido @${username} (${this.perfisSeguidos}/${this.limite})`);
+          }
+        }
+
+        modalInterno.scrollTop += 70;
+        acted = true;
+        break;
+      }
+    }
+
+    if (!acted) {
 
       this.atualizarOverlay('Rolando modal...');
       const prevScroll = modalInterno.scrollTop;

--- a/checker.js
+++ b/checker.js
@@ -42,6 +42,18 @@
       return send('SKIP', 'not_visible');
     }
 
+    const normalize = (s) => (s || '').toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '').trim();
+    const btns = Array.from(document.querySelectorAll('button, [role="button"]'));
+    for (const b of btns) {
+      const t = normalize(b.innerText);
+      const aria = normalize(b.getAttribute('aria-label'));
+      const combo = `${t} ${aria}`;
+      if (combo.includes('seguir de volta') || combo.includes('follow back')) {
+        log('follow back button');
+        return send('FOLLOWS_YOU');
+      }
+    }
+
     const areas = [];
     const main = document.querySelector('main');
     if (main) {

--- a/liker.js
+++ b/liker.js
@@ -1,4 +1,5 @@
 (async () => {
+  // Executado somente quando o perfil foi seguido com sucesso
   const DEBUG = true;
   const log = (...a) => { try { if (DEBUG) console.log('[LIKER]', ...a); } catch(_) {} };
   const sleep = (ms) => new Promise(r => setTimeout(r, ms));


### PR DESCRIPTION
## Summary
- skip accounts showing "follow back" in the followers modal and log the skip reason
- treat profile "follow back" buttons as confirmation the user already follows you
- document that the background and like scripts only run after a successful follow

## Testing
- `npm test`
- `node --check bot.js`
- `node --check checker.js`
- `node --check background.js`
- `node --check liker.js`


------
https://chatgpt.com/codex/tasks/task_e_68a22c8b9b8883268c9f32cfc09bad4e