### PR TITLE
Handle follow-back profiles

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,10 +16,11 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     };
     const finalize = (result, reason) => {
       if (done) return; done = true; cleanup();
-      if (reason) log('finalize', result, reason);
+      if (reason) log('finalize', result, reason); else log('finalize', result);
       const finish = () => {
-        if (prevTabId != null) chrome.tabs.update(prevTabId, { active: true }, () => sendResponse({ result }));
-        else sendResponse({ result });
+        const payload = reason ? { result, reason } : { result };
+        if (prevTabId != null) chrome.tabs.update(prevTabId, { active: true }, () => sendResponse(payload));
+        else sendResponse(payload);
       };
       if (tabId != null) chrome.tabs.remove(tabId, () => finish()); else finish();
     };
@@ -41,7 +42,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       if (res?.type === 'CHECK_RESULT') {
         // FOLLOWS_YOU cobre tanto "Segue você" quanto o botão "Seguir de volta"
         if (res.result === 'FOLLOWS_YOU' || res.result === 'NOT_FOLLOWING') {
-          finalize(res.result);
+          finalize(res.result, res.reason);
         } else if (!secondTry && res.reason === 'not_visible') {
           secondTry = true;
           chrome.tabs.update(tabId, { active: true }, () => setTimeout(() => inject(1), 400));

--- a/bot.js
+++ b/bot.js
@@ -153,10 +153,11 @@ class Bot {
     return new Promise((resolve) => {
       try {
         chrome.runtime.sendMessage({ type: 'CHECK_FOLLOWS_ME', username }, (resp) => {
-          resolve(resp && resp.result);
+          if (resp) resolve(resp);
+          else resolve({ result: 'SKIP' });
         });
       } catch (e) {
-        resolve('SKIP');
+        resolve({ result: 'SKIP' });
       }
     });
   }
@@ -194,10 +195,11 @@ class Bot {
 
       if (t === 'seguir' || t === 'follow') {
         const username = await this.extractUsernameFromFollowButton(btn);
-        const check = await this.requestCheckFollows(username);
+        const { result: check, reason } = await this.requestCheckFollows(username);
         if (check === 'FOLLOWS_YOU') {
-          this.addLog(username, '⏭️ já segue você');
-          this.atualizarOverlay(`@${username} ⏭️ já segue você (${this.perfisSeguidos}/${this.limite})`);
+          const msg = reason === 'follow_back_button' ? '⏭️ já segue (seguir de volta)' : '⏭️ já segue você';
+          this.addLog(username, msg);
+          this.atualizarOverlay(`@${username} ${msg} (${this.perfisSeguidos}/${this.limite})`);
         } else {
           btn.click();
           this.perfisSeguidos++;


### PR DESCRIPTION
## Summary
- detect "Seguir de volta / Follow back" buttons on profile pages with normalized text
- propagate follow-back detection from the checker to background and bot overlays
- skip follow/like actions when profile already follows you

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a230d97e0083269a0cc889d8ccac70