### PR TITLE
Precisely detect follow-back in header

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,6 +2,11 @@
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (!msg) return;
 
+  if (msg.type === 'FOLLOW_DEBUG') {
+    try { console.log('[FOLLOW_DEBUG]', msg); } catch(_) {}
+    return;
+  }
+
   // Novo fluxo de follow (segue no perfil e tenta like opcional)
   if (msg.type === 'FOLLOW_REQUEST' && msg.username) {
     const profileUrl = `https://www.instagram.com/${msg.username}/`;


### PR DESCRIPTION
## Summary
- Enforce strong text normalization to compare follow button labels reliably.
- Scope follow logic to the profile header and pick primary action button based on follow keywords.
- Classify follow/back states with optional "follows you" badge and relay debug info to background service worker.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a246451ff083268fad6d5cf85bedc7