### PR TITLE
Refactor follow logic and mirror debug logs

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (!msg) return;
 
   if (msg.type === 'FOLLOW_DEBUG') {
-    try { console.log('[FOLLOW_DEBUG]', msg); } catch(_) {}
+    try { console.info('[FOLLOW][SW]', msg); } catch(_) {}
     return;
   }
 


### PR DESCRIPTION
## Summary
- Refine follow.js to classify header buttons, click on primary follow button, and confirm resulting state without ever returning CAN_FOLLOW
- Mirror follow debug logs in service worker with `[FOLLOW][SW]`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a24cdd51d88326a9d886184683b822