### PR TITLE
Clear pending action timer on stop

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -282,6 +282,8 @@ class Bot {
     this.rodando = false;
     this.atualizarOverlay('Automação parada');
     clearInterval(this.countdownInterval);
+    clearTimeout(this.nextActionTimer);
+    this.nextActionTimer = null;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure stop() cancels pending actions by clearing nextActionTimer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a25fd474b88326a0552c714e8cf33e