### PR TITLE
feat: inject liker and checker on demand

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,12 @@
       ],
       "js": ["bot.js", "contentscript.js"]
     }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["follow.js", "liker.js", "checker.js"],
+      "matches": ["https://www.instagram.com/*"]
+    }
   ]
 }
 


### PR DESCRIPTION
## Summary
- expose follow, liker and checker scripts via web accessible resources
- fall back to liker.js after follow when needed
- add checker.js endpoint for "follows you" verification

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a265518088832693dd2eb1b7c8a7d8