### PR TITLE
Add basic Jest test suite

### DIFF
--- a/__tests__/background.test.js
+++ b/__tests__/background.test.js
@@ -1,0 +1,9 @@
+describe('background.js', () => {
+  test('registers message listener', () => {
+    global.chrome = { runtime: { onMessage: { addListener: jest.fn() } } };
+    require('../background.js');
+    expect(chrome.runtime.onMessage.addListener).toHaveBeenCalled();
+    const arg = chrome.runtime.onMessage.addListener.mock.calls[0][0];
+    expect(typeof arg).toBe('function');
+  });
+});

--- a/__tests__/bot.test.js
+++ b/__tests__/bot.test.js
@@ -1,0 +1,11 @@
+/** @jest-environment jsdom */
+
+describe('Bot', () => {
+  test('initializes with default values', () => {
+    require('../bot.js');
+    const bot = window.__igBot;
+    expect(bot).toBeDefined();
+    expect(bot.rodando).toBe(false);
+    expect(bot.limite).toBe(10);
+  });
+});

--- a/__tests__/liker.test.js
+++ b/__tests__/liker.test.js
@@ -1,0 +1,13 @@
+/** @jest-environment jsdom */
+
+describe('liker.js', () => {
+  test('sends a message when executed', async () => {
+    jest.useFakeTimers();
+    global.chrome = { runtime: { sendMessage: jest.fn() } };
+    document.body.innerHTML = '<main><article><a href="/p/test/"></a><button aria-label="Unlike" aria-pressed="true"></button></article></main>';
+    require('../liker.js');
+    jest.runAllTimers();
+    await Promise.resolve();
+    expect(chrome.runtime.sendMessage).toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "version": "1.0.0",
   "description": "Chrome extension for Instagram auto-follow bot",
   "scripts": {
-    "test": "echo 'No tests specified'"
+    "test": "jest"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add Jest as dev dependency and update `test` script
- add minimal tests for bot, background, and liker scripts

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a39548641c83269aa6552b7730ef77