### PR TITLE
feat: make debug logging configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# IG Bot 1.0
+
+Chrome extension for Instagram automation.
+
+## Debug logging
+
+`liker.js` can emit verbose logs to help troubleshoot actions. Debug logging is disabled by default. Enable or disable it using one of the following methods:
+
+1. **Extension storage**
+   ```js
+   chrome.storage.local.set({ debug: true });  // enable
+   chrome.storage.local.set({ debug: false }); // disable
+   ```
+   Run these commands from an extension page (for example, the popup's DevTools console). The setting persists between runs.
+
+2. **Runtime message**
+   ```js
+   chrome.runtime.sendMessage({ type: 'SET_DEBUG', debug: true });  // enable
+   chrome.runtime.sendMessage({ type: 'SET_DEBUG', debug: false }); // disable
+   ```
+   This updates the flag for active pages without touching storage.
+
+When the debug flag is true, internal calls to `log` output messages prefixed with `[LIKER]` in the page console.

--- a/liker.js
+++ b/liker.js
@@ -1,6 +1,16 @@
 (async () => {
-  const DEBUG = true;
+  let DEBUG = false;
+  try {
+    DEBUG = await new Promise(resolve => {
+      if (chrome?.storage?.local?.get) {
+        chrome.storage.local.get(['debug'], r => resolve(!!r.debug));
+      } else {
+        resolve(false);
+      }
+    });
+  } catch {}
   const log = (...a) => { try { if (DEBUG) console.log('[LIKER]', ...a); } catch(_) {} };
+  try { chrome.runtime?.onMessage?.addListener(msg => { if (msg?.type === 'SET_DEBUG') DEBUG = !!msg.debug; }); } catch {}
   const sleep = (ms) => new Promise(r => setTimeout(r, ms));
   const waitFor = async (fn, { timeout = 15000, interval = 150 } = {}) => {
     const t0 = Date.now();


### PR DESCRIPTION
## Summary
- allow `liker.js` debug logs to be toggled via storage or runtime message
- add README instructions for enabling/disabling debug logging

## Testing
- `npm test` *(fails: jest-environment-jsdom missing; package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a39a9640288326ab061c29fcd7516c