### PR TITLE
Improve first media liking flow and tab focus

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,14 +3,17 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (!msg || msg.type !== 'LIKE_REQUEST' || !msg.username) return;
 
   const profileUrl = `https://www.instagram.com/${msg.username}/`;
-  let tabId = null, prevTabId = null, done = false, timer = null, secondTry = false;
+  const bringToFront = !!msg.bringToFront;
+  let tabId = null, prevTabId = null, done = false, timer = null, retried = false;
+  const log = (...a) => console.log('[BG]', ...a);
 
   const cleanup = () => {
-    try { chrome.runtime.onMessage.removeListener(onMsg); } catch(_) {}
-    try { chrome.tabs.onUpdated.removeListener(onUpdated); } catch(_) {}
-    try { chrome.tabs.onRemoved.removeListener(onRemoved); } catch(_) {}
+    try { chrome.runtime.onMessage.removeListener(onMsg); } catch (_) {}
+    try { chrome.tabs.onUpdated.removeListener(onUpdated); } catch (_) {}
+    try { chrome.tabs.onRemoved.removeListener(onRemoved); } catch (_) {}
     if (timer) clearTimeout(timer);
   };
+
   const finalize = (result) => {
     if (done) return; done = true; cleanup();
     const finish = () => {
@@ -19,12 +22,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     };
     if (tabId != null) chrome.tabs.remove(tabId, () => finish()); else finish();
   };
+
   const inject = (attempt = 1) => {
     chrome.scripting.executeScript(
       { target: { tabId }, files: ['liker.js'], world: 'MAIN' },
       () => {
         const err = chrome.runtime.lastError && chrome.runtime.lastError.message;
         if (err) {
+          log('inject error', err);
           if (/Frame .* was removed|No frame/i.test(err) && attempt < 4) return setTimeout(() => inject(attempt + 1), 350);
           return finalize('LIKE_SKIP');
         }
@@ -32,30 +37,57 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       }
     );
   };
+
+  const openAndWait = () => {
+    chrome.tabs.update(tabId, { url: profileUrl }, (tab) => {
+      if (chrome.runtime.lastError || !tab?.id) return finalize('LIKE_SKIP');
+      if (bringToFront) {
+        chrome.tabs.update(tabId, { active: true }, () => chrome.windows.update(tab.windowId, { focused: true }));
+      }
+      chrome.tabs.onUpdated.addListener(onUpdated);
+    });
+  };
+
   const onMsg = (res, snd) => {
     if (!snd?.tab || snd.tab.id !== tabId) return;
     if (res?.type === 'LIKE_DONE') return finalize('LIKE_DONE');
     if (res?.type === 'LIKE_SKIP') {
-      if (!secondTry && ['open_failed','like_button_not_found','state_not_changed'].includes(res.reason)) {
-        secondTry = true;
-        chrome.tabs.update(tabId, { active: true }, () => setTimeout(() => inject(1), 400));
+      log('skip received', res.reason);
+      if (!retried && ['interstitial_blocking', 'like_button_not_found', 'state_not_changed', 'open_failed'].includes(res.reason)) {
+        retried = true;
+        log('retrying');
+        chrome.tabs.onUpdated.removeListener(onUpdated);
+        openAndWait();
       } else {
         finalize('LIKE_SKIP');
       }
     }
   };
-  const onUpdated = (id, info) => { if (id === tabId && info.status === 'complete') { chrome.tabs.onUpdated.removeListener(onUpdated); inject(1); } };
+
+  const onUpdated = (id, info) => {
+    if (id === tabId && info.status === 'complete') {
+      chrome.tabs.onUpdated.removeListener(onUpdated);
+      const delay = 400 + Math.random() * 300;
+      log('tab loaded, waiting', delay);
+      setTimeout(() => inject(1), delay);
+    }
+  };
+
   const onRemoved = (id) => { if (id === tabId) finalize('LIKE_SKIP'); };
 
-  timer = setTimeout(() => finalize('LIKE_SKIP'), 45000); // timeout total
+  timer = setTimeout(() => { log('timeout'); finalize('LIKE_SKIP'); }, 60000);
 
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     prevTabId = tabs?.[0]?.id ?? null;
     chrome.runtime.onMessage.addListener(onMsg);
     chrome.tabs.onRemoved.addListener(onRemoved);
-    chrome.tabs.create({ url: profileUrl, active: false }, (tab) => {
+    chrome.tabs.create({ url: profileUrl, active: bringToFront }, (tab) => {
       if (chrome.runtime.lastError || !tab?.id) return finalize('LIKE_SKIP');
       tabId = tab.id;
+      log('tab created', tabId);
+      if (bringToFront) {
+        chrome.tabs.update(tabId, { active: true }, () => chrome.windows.update(tab.windowId, { focused: true }));
+      }
       chrome.tabs.onUpdated.addListener(onUpdated);
     });
   });

--- a/liker.js
+++ b/liker.js
@@ -1,128 +1,217 @@
 let DEBUG = false;
 try {
-  chrome.storage?.local?.get(['debug'], r => { DEBUG = !!r?.debug; });
+  chrome.storage?.local?.get(['debug'], (r) => { DEBUG = !!r?.debug; });
 } catch {}
-const log = (...a) => { try { if (DEBUG) console.log('[LIKER]', ...a); } catch (_) {} };
+const log = (...a) => {
+  try { if (DEBUG) console.log('[LIKER]', ...a); } catch (_) {}
+};
 
-function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
-async function waitFor(fn, timeout = 8000, interval = 120) {
-  const start = Date.now();
-  while (Date.now() - start < timeout) {
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+async function waitFor(pred, timeout = 10000, step = 120) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeout) {
     try {
-      const v = fn();
+      const v = pred();
       if (v) return v;
     } catch {}
-    await sleep(interval);
+    await sleep(step);
   }
   return null;
 }
 
+async function closeInterstitials() {
+  const start = Date.now();
+  while (Date.now() - start < 6000) {
+    if (document.querySelector('form[action*="/accounts/login"], input[name="username"]')) {
+      log('login_required');
+      return { type: 'LIKE_SKIP', reason: 'login_required' };
+    }
+    let acted = false;
+    const cookieBtn = [...document.querySelectorAll('button')].find(
+      (b) => /aceitar|accept|allow/i.test(b.textContent) || (/cookies/i.test(b.textContent) && b.closest('[role="dialog"]'))
+    );
+    if (cookieBtn) {
+      try { cookieBtn.click(); } catch {}
+      acted = true;
+    }
+    const dialogClose = document.querySelector(
+      '[role="dialog"] button[aria-label*="Fechar" i], [role="dialog"] button[aria-label*="Close" i], [role="dialog"] [aria-label*="Fechar" i], [role="dialog"] [aria-label*="Close" i]'
+    );
+    if (dialogClose) {
+      try { dialogClose.click(); } catch {}
+      acted = true;
+    }
+    const sensitiveBtn = [...document.querySelectorAll('button')].find((b) =>
+      /ver foto|see photo|ver conteúdo|see content/i.test(b.textContent)
+    );
+    if (sensitiveBtn) {
+      try { sensitiveBtn.click(); } catch {}
+      acted = true;
+    }
+    if (!acted) await sleep(200);
+  }
+  if (document.querySelector('form[action*="/accounts/login"], input[name="username"]')) {
+    return { type: 'LIKE_SKIP', reason: 'login_required' };
+  }
+  if (document.querySelector('[role="dialog"]')) {
+    log('interstitial_blocking');
+    return { type: 'LIKE_SKIP', reason: 'interstitial_blocking' };
+  }
+  return null;
+}
+
+async function closeMedia(opened) {
+  if (opened === 'modal') {
+    const closeBtn = document.querySelector('button[aria-label*="Fechar" i], button[aria-label*="Close" i]');
+    if (closeBtn) {
+      try { closeBtn.click(); } catch {}
+    } else {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    }
+  } else {
+    history.back();
+    await waitFor(() => /^\/[A-Za-z0-9._]+\/?$/.test(location.pathname), 5000, 200);
+  }
+}
+
+function rateLimited() {
+  const texts = ['Tente novamente mais tarde', 'Try again later', 'Action blocked'];
+  return [...document.querySelectorAll('div,span,p')].some((n) => texts.some((t) => n.textContent.includes(t)));
+}
+
 async function likeFirstMedia() {
   try {
-    const profileRegex = /^https:\/\/www\.instagram\.com\/[^\/]+\/$/;
-    if (!profileRegex.test(location.href)) {
-      log('skip not_profile_page', location.href);
+    const inter = await closeInterstitials();
+    if (inter) return chrome.runtime.sendMessage(inter);
+
+    const path = location.pathname;
+    const profileRegex = /^\/[A-Za-z0-9._]+\/?$/;
+    if (!(profileRegex.test(path) || /^\/(p|reel)\//.test(path))) {
+      log('not_profile_page', path);
       return chrome.runtime.sendMessage({ type: 'LIKE_SKIP', reason: 'not_profile_page' });
     }
 
-    const gridReady = await waitFor(() => document.querySelector('main a[href*="/p/"], main a[href*="/reel/"]'), 12000, 200);
-    if (!gridReady) {
-      log('skip no_clickable_media');
-      return chrome.runtime.sendMessage({ type: 'LIKE_SKIP', reason: 'no_clickable_media' });
-    }
-
-    const anchors = Array.from(document.querySelectorAll('main a[href*="/p/"], main a[href*="/reel/"]'));
+    let mediaType = 'photo';
+    let opened = 'page';
     let target = null;
-    for (const a of anchors) {
-      const href = a.getAttribute('href') || '';
-      if (/\/(p|reel)\//.test(href)) { target = a; break; }
-    }
-    if (!target) {
-      log('skip no_clickable_media valid');
-      return chrome.runtime.sendMessage({ type: 'LIKE_SKIP', reason: 'no_clickable_media' });
-    }
 
-    let mediaType = /\/reel\//.test(target.getAttribute('href')) ? 'reel' : 'photo';
-    const openOnce = async () => {
-      try { target.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
-      await sleep(250 + Math.random() * 150);
-      try { target.click(); } catch {}
-      return await waitFor(() => {
-        if (document.querySelector('[role="dialog"]')) return 'modal';
-        if (/\/(p|reel)\//.test(location.pathname)) return 'page';
-        return null;
-      }, 8000, 200);
-    };
-
-    let opened = await openOnce();
-    if (!opened) {
-      await sleep(400);
+    if (profileRegex.test(path)) {
+      window.scrollTo(0, 0);
+      await sleep(200);
+      const start = Date.now();
+      while (Date.now() - start < 12000) {
+        const anchors = [...document.querySelectorAll('a[href*="/p/"], a[href*="/reel/"]')].filter(
+          (a) => a.offsetParent != null
+        );
+        if (anchors.length) {
+          target = anchors[0];
+          mediaType = /\/reel\//.test(target.getAttribute('href')) ? 'reel' : 'photo';
+          break;
+        }
+        const y = window.scrollY;
+        if (y < 600) window.scrollTo(0, 600);
+        else if (y < 1200) window.scrollTo(0, 1200);
+        await sleep(400);
+      }
+      if (!target) {
+        log('no_clickable_media');
+        return chrome.runtime.sendMessage({ type: 'LIKE_SKIP', reason: 'no_clickable_media' });
+      }
+      const openOnce = async () => {
+        try { target.scrollIntoView({ block: 'center' }); } catch {}
+        await sleep(250 + Math.random() * 250);
+        try { target.click(); } catch {}
+        return await waitFor(
+          () =>
+            document.querySelector('[role="dialog"] article, [role="dialog"] [data-testid="post-container"]')
+              ? 'modal'
+              : /^\/(p|reel)\//.test(location.pathname)
+              ? 'page'
+              : null,
+          8000,
+          200
+        );
+      };
       opened = await openOnce();
       if (!opened) {
-        log('skip open_failed');
+        await sleep(400);
+        opened = await openOnce();
+      }
+      if (!opened) {
+        log('open_failed');
         return chrome.runtime.sendMessage({ type: 'LIKE_SKIP', reason: 'open_failed' });
       }
-    }
-    if (opened === 'page') {
-      mediaType = /\/reel\//.test(location.pathname) ? 'reel' : 'photo';
+      if (opened === 'page') mediaType = /\/reel\//.test(location.pathname) ? 'reel' : 'photo';
+    } else {
+      mediaType = /\/reel\//.test(path) ? 'reel' : 'photo';
+      opened = 'page';
     }
 
-    let usedSelector = '';
+    const scope = opened === 'modal' ? document.querySelector('[role="dialog"]') : document;
     const findLikeBtn = () => {
-      let el = document.querySelector('button[aria-label*="Curtir" i], button[aria-label*="Like" i]');
-      if (el) { usedSelector = 'button[aria-label*="Curtir" i], button[aria-label*="Like" i]'; return el; }
-      el = document.querySelector('svg[aria-label*="Curtir" i], svg[aria-label*="Like" i]');
-      if (el) { usedSelector = 'svg[aria-label*="Curtir" i], svg[aria-label*="Like" i]'; return el.closest('button') || el; }
-      el = document.querySelector('[data-testid*="like" i]');
-      if (el) { usedSelector = '[data-testid*="like" i]'; return el.closest('button') || el; }
+      let el = scope.querySelector('button[aria-label*="Curtir" i], button[aria-label*="Like" i]');
+      if (el) return el;
+      el = scope.querySelector('button[aria-pressed] svg[aria-label*="Curtir" i], button[aria-pressed] svg[aria-label*="Like" i]');
+      if (el) return el.closest('button');
+      el = scope.querySelector('svg[aria-label*="Curtir" i], svg[aria-label*="Like" i]');
+      if (el) return el.closest('button') || el;
+      el = scope.querySelector('[data-testid*="like" i]');
+      if (el) return el.closest('button') || el;
+      el = Array.from(scope.querySelectorAll('[role="button"]')).find((b) =>
+        b.querySelector('svg[aria-label*="Curtir" i], svg[aria-label*="Like" i]')
+      );
+      if (el) return el;
       return null;
     };
-
-    const likeBtn = await waitFor(findLikeBtn, 5000, 120);
+    const likeBtn = await waitFor(findLikeBtn, 6000, 120);
     if (!likeBtn) {
-      log('skip like_button_not_found');
+      log('like_button_not_found');
+      await closeMedia(opened);
       return chrome.runtime.sendMessage({ type: 'LIKE_SKIP', reason: 'like_button_not_found' });
     }
-    log('like button selector:', usedSelector);
 
-    const label = () => (likeBtn.getAttribute('aria-label') || likeBtn.querySelector('svg')?.getAttribute('aria-label') || '').toLowerCase();
-    if (/descurtir|unlike/.test(label())) {
-      log('already liked');
-      if (opened === 'modal') {
-        const closeBtn = document.querySelector('button[aria-label*="Fechar" i], button[aria-label*="Close" i]');
-        if (closeBtn) closeBtn.click(); else document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-      } else {
-        history.back();
-        await waitFor(() => profileRegex.test(location.href), 5000, 200);
-      }
+    const state = () => {
+      const aria = (likeBtn.getAttribute('aria-label') || '').toLowerCase();
+      const pressed = likeBtn.getAttribute('aria-pressed');
+      return {
+        liked: pressed === 'true' || /descurtir|unlike/.test(aria),
+        unliked: pressed === 'false' || /curtir|like/.test(aria),
+      };
+    };
+
+    if (state().liked) {
+      log('already_liked');
+      await closeMedia(opened);
       return chrome.runtime.sendMessage({ type: 'LIKE_DONE', mediaType, alreadyLiked: true });
     }
 
-    const clickAndCheck = async () => {
-      try { likeBtn.scrollIntoView({ block: 'center', inline: 'center' }); } catch {}
+    const clickCheck = async () => {
+      try { likeBtn.scrollIntoView({ block: 'center' }); } catch {}
       try { likeBtn.click(); } catch {}
-      return await waitFor(() => /descurtir|unlike/.test(label()), 6000, 120);
+      await sleep(200 + Math.random() * 150);
+      if (rateLimited()) return 'rate';
+      return await waitFor(() => state().liked, 6000, 120);
     };
 
-    let toggled = await clickAndCheck();
-    if (!toggled) {
-      await sleep(350 + Math.random() * 250);
-      try { likeBtn.click(); } catch {}
-      toggled = await waitFor(() => /descurtir|unlike/.test(label()), 6000, 120);
+    let toggled = await clickCheck();
+    if (toggled === 'rate') {
+      await closeMedia(opened);
+      return chrome.runtime.sendMessage({ type: 'LIKE_SKIP', reason: 'rate_limited' });
     }
     if (!toggled) {
-      log('skip state_not_changed');
+      toggled = await clickCheck();
+      if (toggled === 'rate') {
+        await closeMedia(opened);
+        return chrome.runtime.sendMessage({ type: 'LIKE_SKIP', reason: 'rate_limited' });
+      }
+    }
+    if (!toggled) {
+      log('state_not_changed');
+      await closeMedia(opened);
       return chrome.runtime.sendMessage({ type: 'LIKE_SKIP', reason: 'state_not_changed' });
     }
 
-    if (opened === 'modal') {
-      const closeBtn = document.querySelector('button[aria-label*="Fechar" i], button[aria-label*="Close" i]');
-      if (closeBtn) closeBtn.click(); else document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-    } else {
-      history.back();
-      await waitFor(() => profileRegex.test(location.href), 5000, 200);
-    }
-
+    await closeMedia(opened);
     chrome.runtime.sendMessage({ type: 'LIKE_DONE', mediaType });
   } catch (e) {
     log('error', e?.message);
@@ -133,3 +222,4 @@ async function likeFirstMedia() {
 chrome.runtime.onMessage.addListener((msg) => {
   if (msg?.type === 'LIKE_REQUEST') likeFirstMedia();
 });
+


### PR DESCRIPTION
## Summary
- handle interstitials, rate limits and retries when liking the first media
- wait for tab hydration and optionally bring tab/window to foreground

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6336e5e008326ab869dbf669ff783