### PR TITLE
feat: add local auth with user table and session gating

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -189,6 +189,12 @@ class Bot {
 
   async seguirProximoUsuario() {
     if (!this.rodando) return;
+    const gate = await new Promise((r) => chrome.runtime.sendMessage({ type: 'CAN_RUN' }, r));
+    if (!gate?.ok) {
+      this.atualizarOverlay('Faça login no popup');
+      this.rodando = false;
+      return;
+    }
     const state = await getState();
     if (!state.running) { this.stop(); return; }
     if (state.pausedUntil > Date.now()) {

--- a/popup.html
+++ b/popup.html
@@ -6,22 +6,33 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h2>Instagram Auto Follow Pro v2</h2>
+  <div id="loginView" style="display:none">
+    <h3>Acesso</h3>
+    <input id="loginUser" type="text" placeholder="Usuário" />
+    <input id="loginPass" type="password" placeholder="Senha" />
+    <button id="loginBtn">Entrar</button>
+    <p id="loginMsg" style="font-size:12px;opacity:.8"></p>
+  </div>
+  <div id="appView" style="display:none">
+    <h2>Instagram Auto Follow Pro v2</h2>
 
-  <div id="afStatus"></div>
+    <div id="afStatus"></div>
 
-  <label for="quantidade">Quantidade (1-200):</label>
-  <input type="number" id="quantidade" min="1" max="200" value="10">
+    <label for="quantidade">Quantidade (1-200):</label>
+    <input type="number" id="quantidade" min="1" max="200" value="10">
 
-  <label for="minDelay">Delay mínimo (s):</label>
-  <input type="number" id="minDelay" min="0" value="120">
+    <label for="minDelay">Delay mínimo (s):</label>
+    <input type="number" id="minDelay" min="0" value="120">
 
-  <label for="maxDelay">Delay máximo (s):</label>
-  <input type="number" id="maxDelay" min="0" value="180">
+    <label for="maxDelay">Delay máximo (s):</label>
+    <input type="number" id="maxDelay" min="0" value="180">
 
     <button id="startBtn">Iniciar</button>
     <button id="stopBtn">Parar</button>
+    <button id="logoutBtn">Sair</button>
+  </div>
 
   <script src="popup.js"></script>
 </body>
 </html>
+

--- a/popup.js
+++ b/popup.js
@@ -52,9 +52,65 @@ document.getElementById('startBtn').addEventListener('click', () => {
 });
 
 document.getElementById('stopBtn').addEventListener('click', () => {
-    chrome.storage.local.set({ af_state: { running: false, pausedUntil: 0, consecutiveFails: 0, stage: 0, totalFails: 0 } }, () => {
-        chrome.runtime.sendMessage({ type: 'AF_CLEAR_ALARM' });
-        sendMessageToActiveTab({ action: 'stop' });
-        refreshStatus();
-    });
+    chrome.storage.local.set(
+        { af_state: { running: false, pausedUntil: 0, consecutiveFails: 0, stage: 0, totalFails: 0 } },
+        () => {
+            chrome.runtime.sendMessage({ type: 'AF_CLEAR_ALARM' });
+            sendMessageToActiveTab({ action: 'stop' });
+            refreshStatus();
+        }
+    );
 });
+
+function runtimeSend(msg){
+    return new Promise((resolve) => chrome.runtime.sendMessage(msg, resolve));
+}
+
+async function updateAuthUI() {
+    const status = await runtimeSend({ type: 'AUTH_STATUS' });
+    const loginView = document.getElementById('loginView');
+    const appView = document.getElementById('appView');
+    const loginMsg = document.getElementById('loginMsg');
+    const lockUntil = status.auth_lockUntil || 0;
+    const now = status.now || Date.now();
+    loginMsg.textContent = '';
+    if (lockUntil && lockUntil > now) {
+        loginView.style.display = 'block';
+        appView.style.display = 'none';
+        loginMsg.textContent = 'Bloqueado até ' + new Date(lockUntil).toLocaleTimeString();
+        return;
+    }
+    const auth = status.auth || { state: 'NONE' };
+    if (auth.state === 'AUTH' && (!auth.exp || auth.exp > now)) {
+        loginView.style.display = 'none';
+        appView.style.display = 'block';
+        refreshStatus();
+    } else {
+        loginView.style.display = 'block';
+        appView.style.display = 'none';
+    }
+}
+
+document.getElementById('loginBtn').addEventListener('click', async () => {
+    const user = document.getElementById('loginUser').value.trim();
+    const pass = document.getElementById('loginPass').value;
+    const res = await runtimeSend({ type: 'AUTH_LOGIN', user, pass });
+    if (res.ok) {
+        document.getElementById('loginPass').value = '';
+        updateAuthUI();
+    } else if (res.error === 'LOCKED_UNTIL') {
+        document.getElementById('loginMsg').textContent = 'Bloqueado até ' + new Date(res.lockUntil).toLocaleTimeString();
+    } else {
+        let msg = 'Usuário ou senha inválidos';
+        if (res.lockUntil) msg += ' Bloqueado até ' + new Date(res.lockUntil).toLocaleTimeString();
+        document.getElementById('loginMsg').textContent = msg;
+    }
+});
+
+document.getElementById('logoutBtn').addEventListener('click', async () => {
+    await runtimeSend({ type: 'AUTH_LOGOUT' });
+    updateAuthUI();
+});
+
+updateAuthUI();
+

--- a/style.css
+++ b/style.css
@@ -39,6 +39,18 @@ button:hover {
     background-color: #2a76c0;
 }
 
+#loginView {
+    text-align: center;
+}
+
+#logoutBtn {
+    background-color: #888;
+}
+
+#logoutBtn:hover {
+    background-color: #666;
+}
+
 #autoFollowOverlay {
     position: fixed;
     bottom: 20px;


### PR DESCRIPTION
## Summary
- implement SHA-256 based local authentication with salted/peppered hash table
- add popup login/logout UI with storage-backed session and lockout handling
- gate bot operations with CAN_RUN check

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7c5376e788326a45f6abf2ac967d3