### PR TITLE
Fix async messaging and popup auth checks

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1,116 +1,151 @@
-chrome.storage.sync.get(['minDelay', 'maxDelay', 'limite'], (data) => {
-    document.getElementById('quantidade').value = data.limite || 10;
-    document.getElementById('minDelay').value = data.minDelay || 120;
-    document.getElementById('maxDelay').value = data.maxDelay || 180;
-});
+document.addEventListener('DOMContentLoaded', () => {
+  const loginView = document.getElementById('loginView');
+  const appView = document.getElementById('appView');
+  const loginMsg = document.getElementById('loginMsg');
 
-function refreshStatus() {
+  function showLogin(text = "") {
+    if (loginView) loginView.style.display = 'block';
+    if (appView) appView.style.display = 'none';
+    if (loginMsg) loginMsg.textContent = text || "";
+  }
+
+  function showApp() {
+    if (loginView) loginView.style.display = 'none';
+    if (appView) appView.style.display = 'block';
+    if (loginMsg) loginMsg.textContent = "";
+    refreshStatus();
+  }
+
+  chrome.storage.sync.get(['minDelay', 'maxDelay', 'limite'], (data) => {
+    const quantidade = document.getElementById('quantidade');
+    const minDelay = document.getElementById('minDelay');
+    const maxDelay = document.getElementById('maxDelay');
+    if (quantidade) quantidade.value = data.limite || 10;
+    if (minDelay) minDelay.value = data.minDelay || 120;
+    if (maxDelay) maxDelay.value = data.maxDelay || 180;
+  });
+
+  function refreshStatus() {
     chrome.storage.local.get('af_state', (data) => {
-        const state = data.af_state || {};
-        const el = document.getElementById('afStatus');
-        let text = 'Parado';
-        if (state.running) {
-            if (state.pausedUntil && state.pausedUntil > Date.now()) {
-                text = 'Pausado até ' + new Date(state.pausedUntil).toLocaleTimeString();
-            } else {
-                text = 'Rodando';
-            }
-        } else if (state.stage >= 2) {
-            text = 'Finalizado por limite';
+      const state = data.af_state || {};
+      const el = document.getElementById('afStatus');
+      if (!el) return;
+      let text = 'Parado';
+      if (state.running) {
+        if (state.pausedUntil && state.pausedUntil > Date.now()) {
+          text = 'Pausado até ' + new Date(state.pausedUntil).toLocaleTimeString();
+        } else {
+          text = 'Rodando';
         }
-        el.textContent = text;
+      } else if (state.stage >= 2) {
+        text = 'Finalizado por limite';
+      }
+      el.textContent = text;
     });
-}
+  }
 
-refreshStatus();
-
-chrome.storage.onChanged.addListener((changes, area) => {
+  chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && changes.af_state) refreshStatus();
-});
+  });
 
-function sendMessageToActiveTab(message) {
+  function sendMessageToActiveTab(message) {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-        chrome.tabs.sendMessage(tabs[0].id, message);
+      if (tabs[0]) chrome.tabs.sendMessage(tabs[0].id, message);
     });
-}
+  }
 
-document.getElementById('startBtn').addEventListener('click', () => {
-    const limite = parseInt(document.getElementById('quantidade').value) || 10;
-    const minDelay = parseInt(document.getElementById('minDelay').value) || 120;
-    const maxDelay = parseInt(document.getElementById('maxDelay').value) || 180;
+  document.getElementById('startBtn')?.addEventListener('click', () => {
+    const limite = parseInt(document.getElementById('quantidade')?.value) || 10;
+    const minDelay = parseInt(document.getElementById('minDelay')?.value) || 120;
+    const maxDelay = parseInt(document.getElementById('maxDelay')?.value) || 180;
 
     chrome.storage.sync.set({ minDelay, maxDelay, limite });
 
     chrome.storage.local.get('af_state', (data) => {
-        const st = data.af_state || {};
-        chrome.storage.local.set({ af_state: { ...st, running: true, pausedUntil: 0, consecutiveFails: 0 } }, () => {
-            chrome.runtime.sendMessage({ type: 'AF_CLEAR_ALARM' });
-            sendMessageToActiveTab({ action: 'start', limite, minDelay, maxDelay });
-            refreshStatus();
-        });
-    });
-});
-
-document.getElementById('stopBtn').addEventListener('click', () => {
-    chrome.storage.local.set(
-        { af_state: { running: false, pausedUntil: 0, consecutiveFails: 0, stage: 0, totalFails: 0 } },
+      const st = data.af_state || {};
+      chrome.storage.local.set(
+        { af_state: { ...st, running: true, pausedUntil: 0, consecutiveFails: 0 } },
         () => {
-            chrome.runtime.sendMessage({ type: 'AF_CLEAR_ALARM' });
-            sendMessageToActiveTab({ action: 'stop' });
-            refreshStatus();
+          chrome.runtime.sendMessage({ type: 'AF_CLEAR_ALARM' });
+          sendMessageToActiveTab({ action: 'start', limite, minDelay, maxDelay });
+          refreshStatus();
         }
-    );
-});
+      );
+    });
+  });
 
-function runtimeSend(msg){
-    return new Promise((resolve) => chrome.runtime.sendMessage(msg, resolve));
-}
-
-async function updateAuthUI() {
-    const status = await runtimeSend({ type: 'AUTH_STATUS' });
-    const loginView = document.getElementById('loginView');
-    const appView = document.getElementById('appView');
-    const loginMsg = document.getElementById('loginMsg');
-    const lockUntil = status.auth_lockUntil || 0;
-    const now = status.now || Date.now();
-    loginMsg.textContent = '';
-    if (lockUntil && lockUntil > now) {
-        loginView.style.display = 'block';
-        appView.style.display = 'none';
-        loginMsg.textContent = 'Bloqueado até ' + new Date(lockUntil).toLocaleTimeString();
-        return;
-    }
-    const auth = status.auth || { state: 'NONE' };
-    if (auth.state === 'AUTH' && (!auth.exp || auth.exp > now)) {
-        loginView.style.display = 'none';
-        appView.style.display = 'block';
+  document.getElementById('stopBtn')?.addEventListener('click', () => {
+    chrome.storage.local.set(
+      {
+        af_state: {
+          running: false,
+          pausedUntil: 0,
+          consecutiveFails: 0,
+          stage: 0,
+          totalFails: 0,
+        },
+      },
+      () => {
+        chrome.runtime.sendMessage({ type: 'AF_CLEAR_ALARM' });
+        sendMessageToActiveTab({ action: 'stop' });
         refreshStatus();
-    } else {
-        loginView.style.display = 'block';
-        appView.style.display = 'none';
+      }
+    );
+  });
+
+  async function refreshUI() {
+    let res;
+    try {
+      res = await chrome.runtime.sendMessage({ type: 'AUTH_STATUS' });
+    } catch (e) {
+      console.warn('[POPUP] AUTH_STATUS failed:', e);
+      return showLogin('Carregando autenticação...');
     }
-}
+    const now = (res && res.now) || Date.now();
+    const lockUntil = res?.auth_lockUntil || 0;
+    const authed = !!(
+      res?.auth &&
+      res.auth.state === 'AUTH' &&
+      (!res.auth.exp || res.auth.exp > now)
+    );
 
-document.getElementById('loginBtn').addEventListener('click', async () => {
-    const user = document.getElementById('loginUser').value.trim();
-    const pass = document.getElementById('loginPass').value;
-    const res = await runtimeSend({ type: 'AUTH_LOGIN', user, pass });
-    if (res.ok) {
-        document.getElementById('loginPass').value = '';
-        updateAuthUI();
-    } else if (res.error === 'LOCKED_UNTIL') {
-        document.getElementById('loginMsg').textContent = 'Bloqueado até ' + new Date(res.lockUntil).toLocaleTimeString();
-    } else {
-        let msg = 'Usuário ou senha inválidos';
-        if (res.lockUntil) msg += ' Bloqueado até ' + new Date(res.lockUntil).toLocaleTimeString();
-        document.getElementById('loginMsg').textContent = msg;
+    if (lockUntil > now) {
+      const untilStr = new Date(lockUntil).toLocaleTimeString();
+      return showLogin(`Bloqueado até ${untilStr}.`);
     }
-});
+    if (authed) return showApp();
+    return showLogin('');
+  }
 
-document.getElementById('logoutBtn').addEventListener('click', async () => {
-    await runtimeSend({ type: 'AUTH_LOGOUT' });
-    updateAuthUI();
-});
+  const btnLogin = document.getElementById('loginBtn');
+  const inpUser = document.getElementById('loginUser');
+  const inpPass = document.getElementById('loginPass');
+  const btnLogout = document.getElementById('logoutBtn');
 
-updateAuthUI();
+  btnLogin?.addEventListener('click', async () => {
+    const user = inpUser?.value || '';
+    const pass = inpPass?.value || '';
+    let r;
+    try {
+      r = await chrome.runtime.sendMessage({ type: 'AUTH_LOGIN', user, pass });
+    } catch (e) {
+      return showLogin('Falha de comunicação.');
+    }
+    if (r?.ok) return refreshUI();
+    if (r?.error === 'LOCKED_UNTIL') {
+      const untilStr = new Date(r.lockUntil).toLocaleTimeString();
+      return showLogin(`Bloqueado até ${untilStr}.`);
+    }
+    return showLogin('Usuário ou senha inválidos.');
+  });
+
+  btnLogout?.addEventListener('click', async () => {
+    try {
+      await chrome.runtime.sendMessage({ type: 'AUTH_LOGOUT' });
+    } catch (e) {}
+    refreshUI();
+  });
+
+  refreshUI();
+});
 


### PR DESCRIPTION
## Summary
- handle async background messages with safe defaults and always respond
- guard popup auth status and avoid blank screen

## Testing
- `node --check background.js`
- `node --check popup.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7cd87926483269a57a81bd31f8d12